### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/olegantonyan/super_awesome_print. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/olegantonyan/super_awesome_print. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://www.contributor-covenant.org) code of conduct.
 
 
 ## License

--- a/super_awesome_print.gemspec
+++ b/super_awesome_print.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Simple wrapper around awesome_print for easier look in long log}
   spec.description   = %q{Add colored '*********', time and line number around printed value}
-  spec.homepage      = "http://github.com/olegantonyan/super_awesome_printsuper_awesome_print"
+  spec.homepage      = "http://github.com/olegantonyan/super_awesome_print"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }


### PR DESCRIPTION
Link to homepage in gemspec had a duplicated repo name
Link to Contributor Covenant was missing `http://www.` which directed to GitHub.
