### PR TITLE
Add configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Or install it yourself as:
 
     $ gem install super_awesome_print
 
+You can optionally customize configuration in an initializer.<br/>
+In Rails, you can add the following to `config/initializers/super_awesome_print.rb`:
+
+```ruby
+SuperAwesomePrint.configure do |config|
+  config.caller_lines = 3 # defaults to 1
+  config.blank_lines_top = 2 # defaults to 0
+  config.blank_lines_bottom = 2 # defaults to 0
+end
+```
+
 ## Usage
 
 Just use `sap` global function to print any variable.

--- a/lib/super_awesome_print.rb
+++ b/lib/super_awesome_print.rb
@@ -1,14 +1,50 @@
 require 'super_awesome_print/version'
+require 'super_awesome_print/configuration'
 require 'awesome_print'
 
 def sap(msg)
+  blank_lines_top
   ap "*** #{Time.now} ***", color: { string: :green }
   ap msg.class if msg.respond_to?(:class)
-  src = caller.first.gsub(Rails.root.to_s + '/', '')
-  ap src, color: { string: :purpleish }
+  print_caller_lines(caller)
   ap msg
   ap '*** END ***', color: { string: :green }
+  blank_lines_bottom
+end
+
+def print_caller_lines(caller_array)
+  number_of_lines = config.caller_lines
+  lines = caller_array[0...number_of_lines].map do |line|
+    line.gsub(Rails.root.to_s + '/', '')
+  end
+  lines.each { |line| ap line, color: { string: :purpleish } }
+end
+
+def blank_lines_top
+  # The first puts has no visible effect
+  # So we want to puts once regardless of config
+  puts
+  config.blank_lines_top.times { puts }
+end
+
+def blank_lines_bottom
+  config.blank_lines_bottom.times { puts }
+end
+
+def config
+  SuperAwesomePrint.configuration
 end
 
 module SuperAwesomePrint
+  class << self
+    attr_writer :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration
+  end
 end

--- a/lib/super_awesome_print.rb
+++ b/lib/super_awesome_print.rb
@@ -3,41 +3,41 @@ require 'super_awesome_print/configuration'
 require 'awesome_print'
 
 def sap(msg)
-  blank_lines_top
+  SuperAwesomePrint.blank_lines_top
   ap "*** #{Time.now} ***", color: { string: :green }
   ap msg.class if msg.respond_to?(:class)
-  print_caller_lines(caller)
+  SuperAwesomePrint.print_caller_lines(caller)
   ap msg
   ap '*** END ***', color: { string: :green }
-  blank_lines_bottom
-end
-
-def print_caller_lines(caller_array)
-  number_of_lines = config.caller_lines
-  lines = caller_array[0...number_of_lines].map do |line|
-    line.gsub(Rails.root.to_s + '/', '')
-  end
-  lines.each { |line| ap line, color: { string: :purpleish } }
-end
-
-def blank_lines_top
-  # The first puts has no visible effect
-  # So we want to puts once regardless of config
-  puts
-  config.blank_lines_top.times { puts }
-end
-
-def blank_lines_bottom
-  config.blank_lines_bottom.times { puts }
-end
-
-def config
-  SuperAwesomePrint.configuration
+  SuperAwesomePrint.blank_lines_bottom
 end
 
 module SuperAwesomePrint
   class << self
     attr_writer :configuration
+  end
+
+  def self.print_caller_lines(caller_array)
+    number_of_lines = config.caller_lines
+    lines = caller_array[0...number_of_lines].map do |line|
+      line.gsub(Rails.root.to_s + '/', '')
+    end
+    lines.each { |line| ap line, color: { string: :purpleish } }
+  end
+
+  def self.blank_lines_top
+    # The first puts has no visible effect
+    # So we want to puts once regardless of config
+    puts
+    config.blank_lines_top.times { puts }
+  end
+
+  def self.blank_lines_bottom
+    config.blank_lines_bottom.times { puts }
+  end
+
+  def self.config
+    SuperAwesomePrint.configuration
   end
 
   def self.configuration

--- a/lib/super_awesome_print/configuration.rb
+++ b/lib/super_awesome_print/configuration.rb
@@ -1,0 +1,9 @@
+class Configuration
+  attr_accessor :caller_lines, :blank_lines_top, :blank_lines_bottom
+
+  def initialize
+    @caller_lines = 1
+    @blank_lines_top = 0
+    @blank_lines_bottom = 0
+  end
+end


### PR DESCRIPTION
Create a configuration class that will allow for setting configuration options via an initializer.

Options added in this commit are for the number of backtrace lines to show, as well as how many newlines to have before and after each output.
