### PR TITLE
Allow to specify root_path in configuration (defaults to Rails.root)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ SuperAwesomePrint.configure do |config|
   config.caller_lines = 3 # defaults to 1
   config.blank_lines_top = 2 # defaults to 0
   config.blank_lines_bottom = 2 # defaults to 0
+  config.root_path = Rails.root.to_s # this path will be removed from caller's files path, defaults to Rails.root.to_s
 end
 ```
 

--- a/lib/super_awesome_print.rb
+++ b/lib/super_awesome_print.rb
@@ -20,7 +20,7 @@ module SuperAwesomePrint
   def self.print_caller_lines(caller_array)
     number_of_lines = config.caller_lines
     lines = caller_array[0...number_of_lines].map do |line|
-      line.gsub(Rails.root.to_s + '/', '')
+      line.gsub(config.root_path + '/', '')
     end
     lines.each { |line| ap line, color: { string: :purpleish } }
   end

--- a/lib/super_awesome_print/configuration.rb
+++ b/lib/super_awesome_print/configuration.rb
@@ -1,9 +1,10 @@
 class Configuration
-  attr_accessor :caller_lines, :blank_lines_top, :blank_lines_bottom
+  attr_accessor :caller_lines, :blank_lines_top, :blank_lines_bottom, :root_path
 
   def initialize
     @caller_lines = 1
     @blank_lines_top = 0
     @blank_lines_bottom = 0
+    @root_path = defined?(Rails) ? Rails.root.to_s : ''
   end
 end


### PR DESCRIPTION
@mkunkel I think this is a good idea to not depend on Rails. So I've added an option to set root path which will be removed from the file path. By default it will try `Rails.root`, but if there is no Rails it won't blow up.
